### PR TITLE
Do not attempt to iterate on an empty nodelist.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ module.exports = function nodeToObject(node) {
   assert(node.dir, 'Passed etcd must be a directory')
 
   var r = {}
+  if (!node.nodes) return r
+
   node.nodes.forEach(function (childNode) {
     var split = childNode.key.split('/')
     var key = split[split.length - 1]

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -30,9 +30,16 @@ var testNode = {
   "createdIndex": 35
 }
 
+var testEmptyDir = {
+  "key": "/empty",
+  "dir": true
+}
+
 assert.deepEqual(etcdResultObjectify(testNode), {
   foo: 'bar',
   zar: {
     far: 'bar'
   }
 })
+
+assert.deepEqual(etcdResultObjectify(testEmptyDir), {})


### PR DESCRIPTION
Directories that have no entries in them will have `dir` true but won't have a `nodes` field. Skip over these directories.

Bonus! A test that fails without this change.