### PR TITLE
Fix crash when encountering an empty etcd directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,15 +4,16 @@ module.exports = function nodeToObject(node) {
   assert(node.dir, 'Passed etcd must be a directory')
 
   var r = {}
-  node.nodes.forEach(function (childNode) {
-    var split = childNode.key.split('/')
-    var key = split[split.length - 1]
+  if (node && node.nodes) {
+    node.nodes.forEach(function (childNode) {
+      var split = childNode.key.split('/')
+      var key = split[split.length - 1]
 
-    if (childNode.dir)
-      r[key] = nodeToObject(childNode)
-    else
-      r[key] = childNode.value
-  });
-
+      if (childNode.dir)
+        r[key] = nodeToObject(childNode)
+      else
+        r[key] = childNode.value
+    });
+  }
   return r
 }

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -24,7 +24,13 @@ var testNode = {
     ],
     "modifiedIndex": 53,
     "createdIndex": 53
-  }
+  },
+    {
+      "key": "/emptyDirectory",
+      "dir": true,
+      "modifiedIndex": 54,
+      "createdIndex": 54
+    }
   ],
   "modifiedIndex": 35,
   "createdIndex": 35
@@ -34,5 +40,6 @@ assert.deepEqual(etcdResultObjectify(testNode), {
   foo: 'bar',
   zar: {
     far: 'bar'
-  }
+  },
+  emptyDirectory: {}
 })


### PR DESCRIPTION
Hi, Maciej!

Hope you are well!

I encountered a bug in etcd-result-objectify.  Weirdly, etcd omits the 'nodes' key for empty directories.  This causes this library to throw an exception when it tries to call forEach against undefined.  Added a defined-ness check to fix this.

Best,
Brian