### PR TITLE
(bug) return object on non-array

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = function nodeToObject(node) {
   assert(node.dir, 'Passed etcd must be a directory')
 
   var r = {}
+  if (!Array.isArray(node.nodes)) return r
   node.nodes.forEach(function (childNode) {
     var split = childNode.key.split('/')
     var key = split[split.length - 1]

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -24,6 +24,10 @@ var testNode = {
     ],
     "modifiedIndex": 53,
     "createdIndex": 53
+  },
+  {
+    "key": "/registrations/beep",
+    dir: true
   }
   ],
   "modifiedIndex": 35,
@@ -34,5 +38,6 @@ assert.deepEqual(etcdResultObjectify(testNode), {
   foo: 'bar',
   zar: {
     far: 'bar'
-  }
+  },
+  beep: {}
 })


### PR DESCRIPTION
If you have a dir in etcd but none without values, this causes this lib to crash.

Since we're dealing with human input, and humans are imperfect, we should
let the software help us out :)